### PR TITLE
Fix for #24 Money serialization fails

### DIFF
--- a/NodaMoney.UnitTests/CurrencyTests.cs
+++ b/NodaMoney.UnitTests/CurrencyTests.cs
@@ -357,9 +357,9 @@ namespace NodaMoney.UnitTests
             }
 
             [TestMethod]
-            public void WhenDecimalDigitIsHigherThenThree_ThenCreatingShouldThrow()
+            public void WhenDecimalDigitIsHigherThenFour_ThenCreatingShouldThrow()
             {
-                Action action = () => { var eur = new Currency("EUR", "978", 4, "Euro", "€"); };
+                Action action = () => { var eur = new Currency("EUR", "978", 5, "Euro", "€"); };
 
                 action.ShouldThrow<ArgumentOutOfRangeException>();
             }

--- a/NodaMoney.UnitTests/MoneySerializableTests.cs
+++ b/NodaMoney.UnitTests/MoneySerializableTests.cs
@@ -144,7 +144,18 @@ namespace NodaMoney.UnitTests
             }
         }
 
-        [TestClass]
+		[DataContract]
+	    public class Article
+	    {
+			[DataMember]
+			public int Id { get; set; }
+			[DataMember]
+			public string Name { get; set; }
+			[DataMember]
+		    public Money Amount { get; set; }
+	    }
+
+	    [TestClass]
         public class GivenIWantToSerializeMoneyWithDataContractSerializer
         {
             private Money yen = new Money(765m, Currency.FromCode("JPY"));
@@ -165,6 +176,21 @@ namespace NodaMoney.UnitTests
 
                 euro.Should().Be(Clone<Money>(euro));
             }
+
+	        [TestMethod]
+	        public void WhenSerializingArticle_ThenThisShouldSucceed()
+	        {
+		        var article = new Article
+		        {
+			        Id = 123,
+			        Amount = Money.Euro(27.15),
+			        Name = "Foo"
+		        };
+
+				Console.WriteLine(StreamToString(Serialize(article)));
+
+				article.Amount.Should().Be(Clone<Article>(article).Amount);
+	        }
 
             public static Stream Serialize(object source)
             {

--- a/NodaMoney.UnitTests/NodaMoney.UnitTests.csproj
+++ b/NodaMoney.UnitTests/NodaMoney.UnitTests.csproj
@@ -37,17 +37,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions">
+      <HintPath>..\..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core">
+      <HintPath>..\..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Runtime.Serialization" />
@@ -119,6 +116,13 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NodaMoney/Currency.cs
+++ b/NodaMoney/Currency.cs
@@ -45,8 +45,8 @@ namespace NodaMoney
                 throw new ArgumentNullException("englishName");
             if (string.IsNullOrWhiteSpace(sign)) 
                 throw new ArgumentNullException("sign");
-            if (decimalDigits < -1 || decimalDigits > 3)
-                throw new ArgumentOutOfRangeException("code", "DecimalDigits must be between -1 and 3!");
+            if (decimalDigits < -1 || decimalDigits > 4)
+                throw new ArgumentOutOfRangeException("code", "DecimalDigits must be between -1 and 4!");
 
             Code = code;
             Number = number;

--- a/NodaMoney/Money.Serializable.cs
+++ b/NodaMoney/Money.Serializable.cs
@@ -34,7 +34,7 @@ namespace NodaMoney
             if (reader == null)
                 throw new ArgumentNullException("reader");
 
-            if (reader.MoveToContent() != XmlNodeType.Element || reader.LocalName != "Money")
+            if (reader.MoveToContent() != XmlNodeType.Element)
                 throw new SerializationException("Couldn't find content element with name Money!");
 
             Amount = decimal.Parse(reader["Amount"], CultureInfo.InvariantCulture);

--- a/NodaMoney/NodaMoney.csproj
+++ b/NodaMoney/NodaMoney.csproj
@@ -15,7 +15,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+	<SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>2137d63e</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/NodaMoney/NodaMoney.csproj
+++ b/NodaMoney/NodaMoney.csproj
@@ -17,7 +17,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>ffe7e859</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>2137d63e</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -75,17 +75,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net45+wp80+win8+wpa81+aspnetcore50\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net45+wp80+win8+wpa81+aspnetcore50\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets'))" />
   </Target>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NodaMoney/packages.config
+++ b/NodaMoney/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="portable-net45+win+wpa81+wp80" />
-  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="portable-net45+win+wpa81+wp80" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
I've added a unittest showing the bug described in issue #24 and fixed the problem by simply removing the check for reader.LocalName

This pull request also contains a fix for the broken Currency class, a failure introduced by the last commit on the develop branch.