### PR TITLE
Fixed nullable Money deserialization

### DIFF
--- a/src/NodaMoney.Serialization.AspNet/MoneyJavaScriptConverter.cs
+++ b/src/NodaMoney.Serialization.AspNet/MoneyJavaScriptConverter.cs
@@ -15,7 +15,7 @@ namespace NodaMoney.Serialization.AspNet
     public class MoneyJavaScriptConverter : JavaScriptConverter
     {
         /// <summary>When overridden in a derived class, gets a collection of the supported types.</summary>
-        public override IEnumerable<Type> SupportedTypes => new ReadOnlyCollection<Type>(new List<Type>(new[] { typeof(Money) }));
+        public override IEnumerable<Type> SupportedTypes => new ReadOnlyCollection<Type>(new List<Type>(new[] { typeof(Money), typeof(Money?) }));
 
         /// <summary>When overridden in a derived class, converts the provided dictionary into an object of the specified type.</summary>
         /// <param name="dictionary">An <see cref="T:System.Collections.Generic.IDictionary`2" /> instance of property data stored as name/value pairs.</param>
@@ -28,7 +28,8 @@ namespace NodaMoney.Serialization.AspNet
         {
             if (dictionary == null)
                 throw new ArgumentNullException(nameof(dictionary));
-            if (type != typeof(Money))
+
+            if (type != typeof(Money) && type != typeof(Money?))
                 throw new ArgumentException("object should be of type Money to deserialize!", nameof(type));
 
             if (!dictionary.ContainsKey("amount"))

--- a/src/NodaMoney/Serialization/JsonNet/MoneyJsonConverter.cs
+++ b/src/NodaMoney/Serialization/JsonNet/MoneyJsonConverter.cs
@@ -52,6 +52,9 @@ namespace NodaMoney.Serialization.JsonNet
             if (reader == null)
                 throw new ArgumentNullException(nameof(reader));
 
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
             JObject jsonObject = JObject.Load(reader);
             var properties = jsonObject.Properties().ToList();
 


### PR DESCRIPTION
# Description
Currently deserialization of Money type for Json fails for nullable nested properties like `{ cash: null }` for type like:
```
class TypeWithNullableMoneyProperty
{
    public Money? Cash { get; set; }
}
```
Money type deserializers should be able to deserialize that

## Type of change

Added possibility to pass nullable amount value to `MoneyJavaScriptConverter` and `MoneyJavaScriptConverter` by allowing to handle also `Money?` type and adding code for returning null in that case.

Fixed also inverted names for previously added tests scenarios

 [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added new set of tests (for both deserialization ways)

- [x] WhenDeserializingWithNested_ThenThisShouldSucceed
- [x] WhenDeserializingWithNestedNullable_ThenThisShouldSucceed

## Steps to Test or Reproduce
Run newly added tests without changes to the code