### PR TITLE
Move ExchangeRate rounding to constructors with doubles

### DIFF
--- a/src/NodaMoney/ExchangeRate.cs
+++ b/src/NodaMoney/ExchangeRate.cs
@@ -30,15 +30,16 @@ namespace NodaMoney
 
             BaseCurrency = baseCurrency;
             QuoteCurrency = quoteCurrency;
-            Value = Math.Round(rate, 6); // value is a ratio
+            Value = rate; // value is a ratio
         }
 
         /// <summary>Initializes a new instance of the <see cref="ExchangeRate"/> struct.</summary>
         /// <param name="baseCurrency">The base currency.</param>
         /// <param name="quoteCurrency">The quote currency.</param>
         /// <param name="rate">The rate of the exchange.</param>
-        public ExchangeRate(Currency baseCurrency, Currency quoteCurrency, double rate)
-            : this(baseCurrency, quoteCurrency, (decimal)rate)
+        /// <param name="numberOfDecimals">The number of decimals to round the exchange rate to.</param>
+        public ExchangeRate(Currency baseCurrency, Currency quoteCurrency, double rate, int numberOfDecimals = 6)
+            : this(baseCurrency, quoteCurrency, Math.Round((decimal)rate, numberOfDecimals))
         {
         }
 
@@ -55,8 +56,9 @@ namespace NodaMoney
         /// <param name="baseCode">The code of the base currency.</param>
         /// <param name="quoteCode">The code of the quote currency.</param>
         /// <param name="rate">The rate of the exchange.</param>
-        public ExchangeRate(string baseCode, string quoteCode, double rate)
-            : this(Currency.FromCode(baseCode), Currency.FromCode(quoteCode), rate)
+        /// <param name="numberOfDecimals">The number of decimals to round the exchange rate to.</param>
+        public ExchangeRate(string baseCode, string quoteCode, double rate, int numberOfDecimals = 6)
+            : this(Currency.FromCode(baseCode), Currency.FromCode(quoteCode), rate, numberOfDecimals)
         {
         }
 

--- a/tests/NodaMoney.Tests/ExchangeRateSpec.cs
+++ b/tests/NodaMoney.Tests/ExchangeRateSpec.cs
@@ -49,14 +49,23 @@ namespace NodaMoney.Tests.ExchangeRateSpec
         private readonly Currency _dollar = Currency.FromCode("USD");
 
         [Fact]
-        public void WhenRateIsDouble_ThenCreatingShouldSucceed()
+        public void WhenRateIsDoubleAndNoNumberRoundingDecimalsIsGiven_ThenCreatingShouldSucceedWithValueRoundedToSixDecimals()
         {
-            var fx = new ExchangeRate(_euro, _dollar, 1.2591);
+            var fx = new ExchangeRate(_euro, _dollar, 1.2591478D);
 
             fx.BaseCurrency.Should().Be(_euro);
             fx.QuoteCurrency.Should().Be(_dollar);
-            // TODO: Can doubles be compared for equality? See https://github.com/dennisdoomen/fluentassertions/wiki
-            fx.Value.Should().Be(1.2591M);
+            fx.Value.Should().Be(1.259148M);
+        }
+
+        [Fact]
+        public void WhenRateIsDoubleAndANumberOfRoundingDecimalsIsGiven_ThenCreatingShouldSucceedWithValueRoundedThatNumberOfDecimals()
+        {
+            var fx = new ExchangeRate(_euro, _dollar, 1.2591478D, 3);
+
+            fx.BaseCurrency.Should().Be(_euro);
+            fx.QuoteCurrency.Should().Be(_dollar);
+            fx.Value.Should().Be(1.259M);
         }
 
         [Fact]
@@ -70,13 +79,23 @@ namespace NodaMoney.Tests.ExchangeRateSpec
         }
 
         [Fact]
-        public void WhenRateIsFloat_ThenCreatingShouldSucceed()
+        public void WhenRateIsFloatAndNoNumberRoundingDecimalsIsGiven_ThenCreatingShouldSucceedWithValueRoundedToSixDecimals()
         {
-            var fx = new ExchangeRate(_euro, _dollar, 1.2591F);
+            var fx = new ExchangeRate(_euro, _dollar, 1.2591478F);
 
             fx.BaseCurrency.Should().Be(_euro);
             fx.QuoteCurrency.Should().Be(_dollar);
-            fx.Value.Should().Be(1.2591M);
+            fx.Value.Should().Be(1.259148M);
+        }
+
+        [Fact]
+        public void WhenRateIsFloatAndANumberOfRoundingDecimalsIsGiven_ThenCreatingShouldSucceedWithValueRoundedThatNumberOfDecimals()
+        {
+            var fx = new ExchangeRate(_euro, _dollar, 1.2591478F, 3);
+
+            fx.BaseCurrency.Should().Be(_euro);
+            fx.QuoteCurrency.Should().Be(_dollar);
+            fx.Value.Should().Be(1.259M);
         }
 
         [Fact]
@@ -111,14 +130,23 @@ namespace NodaMoney.Tests.ExchangeRateSpec
         private readonly Currency _dollar = Currency.FromCode("USD");
 
         [Fact]
-        public void WhenRateIsDouble_ThenCreatingShouldSucceed()
+        public void WhenRateIsDoubleAndNoNumberRoundingDecimalsIsGiven_ThenCreatingShouldSucceedWithValueRoundedToSixDecimals()
         {
-            var fx = new ExchangeRate(_euroAsString, _dollarAsString, 1.2591);
+            var fx = new ExchangeRate(_euroAsString, _dollarAsString, 1.2591478D);
 
             fx.BaseCurrency.Should().Be(_euro);
             fx.QuoteCurrency.Should().Be(_dollar);
-            // TODO: Can doubles be compared for equality? See https://github.com/dennisdoomen/fluentassertions/wiki
-            fx.Value.Should().Be(1.2591M);
+            fx.Value.Should().Be(1.259148M);
+        }
+
+        [Fact]
+        public void WhenRateIsDoubleAndANumberOfRoundingDecimalsIsGiven_ThenCreatingShouldSucceedWithValueRoundedThatNumberOfDecimals()
+        {
+            var fx = new ExchangeRate(_euroAsString, _dollarAsString, 1.2591478D, 3);
+
+            fx.BaseCurrency.Should().Be(_euro);
+            fx.QuoteCurrency.Should().Be(_dollar);
+            fx.Value.Should().Be(1.259M);
         }
 
         [Fact]
@@ -132,13 +160,23 @@ namespace NodaMoney.Tests.ExchangeRateSpec
         }
 
         [Fact]
-        public void WhenRateIsFloat_ThenCreatingShouldSucceed()
+        public void WhenRateIsFloatAndNoNumberOfRoundingDecimalsIsGiven_ThenCreatingShouldSucceedWithValueRoundedToSixDecimals()
         {
-            var fx = new ExchangeRate(_euroAsString, _dollarAsString, 1.2591F);
+            var fx = new ExchangeRate(_euroAsString, _dollarAsString, 1.2591478F);
 
             fx.BaseCurrency.Should().Be(_euro);
             fx.QuoteCurrency.Should().Be(_dollar);
-            fx.Value.Should().Be(1.2591M);
+            fx.Value.Should().Be(1.259148M);
+        }
+
+        [Fact]
+        public void WhenRateIsFloatAndANumberOfRoundingDecimalsIsGiven_ThenCreatingShouldSucceedWithValueRoundedThatNumberOfDecimals()
+        {
+            var fx = new ExchangeRate(_euroAsString, _dollarAsString, 1.2591478F, 3);
+
+            fx.BaseCurrency.Should().Be(_euro);
+            fx.QuoteCurrency.Should().Be(_dollar);
+            fx.Value.Should().Be(1.259M);
         }
 
         [Fact]


### PR DESCRIPTION
I have moved the rounding behavior of the `ExchangeRate` object to the constructors that accept doubles instead of decimals. To make it more explicit, I added a fourth parameter to the double accepting constructor `numberOfDecimals`, indicating to how many decimals the exchange rate should be rounded.

To make the `double` accepting constructors backward compatible, the default value for `numberOfDecimals` is set to 6. 

The `decimal` accepting constructors now have different behavior as they won't be rounded in the constructor.

This fixes #60.