### PR TITLE
To string changes

### DIFF
--- a/src/NodaMoney/Money.Formattable.cs
+++ b/src/NodaMoney/Money.Formattable.cs
@@ -18,13 +18,8 @@ namespace NodaMoney
         /// using the specified format.</summary>
         /// <param name="format">A numeric format string.</param>
         /// <returns>The string representation of this <see cref="Money"/> instance as specified by the format.</returns>
-        /// <exception cref="ArgumentNullException">The value of 'format' cannot be null.</exception>
         public string ToString(string format)
         {
-            // http://msdn.microsoft.com/en-us/library/syy068tk.aspx
-            if (format == null)
-                throw new ArgumentNullException(nameof(format));
-
             return ConvertToString(format, null);
         }
 
@@ -32,12 +27,8 @@ namespace NodaMoney
         /// specified culture-specific format information.</summary>
         /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information.</param>
         /// <returns>The string representation of this <see cref="Money"/> instance as specified by formatProvider.</returns>
-        /// <exception cref="ArgumentNullException">The value of 'formatProvider' cannot be null.</exception>
         public string ToString(IFormatProvider formatProvider)
         {
-            if (formatProvider == null)
-                throw new ArgumentNullException(nameof(formatProvider));
-
             return ConvertToString(null, formatProvider);
         }
 

--- a/src/NodaMoney/Money.Formattable.cs
+++ b/src/NodaMoney/Money.Formattable.cs
@@ -122,6 +122,11 @@ namespace NodaMoney
                 provider = GetFormatProvider(Currency, formatProvider);
             }
 
+            if (format == null || format == "G")
+            {
+                format = "C";
+            }
+
             return Amount.ToString(format ?? "C", provider);
         }
     }

--- a/tests/NodaMoney.Tests/MoneyFormattableSpec.cs
+++ b/tests/NodaMoney.Tests/MoneyFormattableSpec.cs
@@ -105,6 +105,23 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
             oneParameter().Should().Be(twoParameter());
         }
 
+        [Fact]
+        public void WhenUsingToStringWithGFormat_ThenReturnsTheSameAsTheDefaultFormat()
+        {
+            // according to https://docs.microsoft.com/en-us/dotnet/api/system.iformattable.tostring?view=netframework-4.7.2#notes-to-implementers
+            // the result of using "G" should return the same result as using <null>
+            _yen.ToString("G", null).Should().Be(_yen.ToString(null, null));
+        }
+
+        [Fact]
+        public void WhenUsingToStringWithGFormatWithCulture_ThenReturnsTheSameAsTheDefaultFormatWithThatCulture()
+        {
+            _yen.ToString("G", CultureInfo.InvariantCulture).Should().Be(_yen.ToString(null, CultureInfo.InvariantCulture));
+            _yen.ToString("G", CultureInfo.GetCultureInfo("nl-NL")).Should().Be(_yen.ToString(null, CultureInfo.GetCultureInfo("nl-NL")));
+            _yen.ToString("G", CultureInfo.GetCultureInfo("fr-FR")).Should().Be(_yen.ToString(null, CultureInfo.GetCultureInfo("fr-FR")));
+        }
+
+
     }
 
     public class GivenIWantMoneyAsStringWithCurrencySymbol

--- a/tests/NodaMoney.Tests/MoneyFormattableSpec.cs
+++ b/tests/NodaMoney.Tests/MoneyFormattableSpec.cs
@@ -48,11 +48,11 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
         }
 
         [Fact]
-        public void WhenNullFormat_ThenThisShouldThrow()
+        public void WhenNullFormat_ThenThisShouldNotThrow()
         {
             Action action = () => _yen.ToString((string)null);
 
-            action.ShouldThrow<ArgumentNullException>();
+            action.ShouldNotThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -80,12 +80,31 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
         }
 
         [Fact]
-        public void WhenNullFormatNumberFormatIsUsed_ThenThisShouldThrow()
+        public void WhenNullFormatNumberFormatIsUsed_ThenThisShouldNotThrow()
         {
             Action action = () => _yen.ToString((NumberFormatInfo)null);
 
-            action.ShouldThrow<ArgumentNullException>();
+            action.ShouldNotThrow<ArgumentNullException>();
         }
+
+        [Fact]
+        public void WhenUsingToStringWithOneStringArgument_ThenExpectsTheSameAsWithTwoArguments()
+        {
+            Func<string> oneParameter = () => _yen.ToString((string)null);
+            Func<string> twoParameter = () => _yen.ToString((string)null, null);
+
+            oneParameter().Should().Be(twoParameter());
+        }
+
+        [Fact]
+        public void WhenUsingToStringWithOneProviderArgument_ThenExpectsTheSameAsWithTwoArguments()
+        {
+            Func<string> oneParameter = () => _yen.ToString((IFormatProvider)null);
+            Func<string> twoParameter = () => _yen.ToString(null, null);
+
+            oneParameter().Should().Be(twoParameter());
+        }
+
     }
 
     public class GivenIWantMoneyAsStringWithCurrencySymbol


### PR DESCRIPTION
This is my first pull request, I hope I did everything correctly.

I ran into your library when I was trying to implement something similar myself and I would like to contribute. To get familiar with the library and using GitHub correctly I started with small changes:
 
There are some implementation notes for implementing the IFormattable interface, see: https://docs.microsoft.com/en-us/dotnet/api/system.iformattable.tostring?view=netframework-4.7.2#notes-to-implementers, see also https://stackoverflow.com/questions/14221424/reference-implementation-for-iformattable for a summary.
In this pull request I added those implementation notes to the library and included the corresponding tests. 

Also I noted different behavior for `ToString` when it was called with one and two arguments. As a consumer of the library would (I think) expect that `ToString((string)null)` would ultimately call `ToString(null, null)` instead of throwing an exception. Technically this is not part of the `IFormattable` interface, since the one-argument ToString is not part of IFormattable but to me it seems closely related. 

To be in line with the behavior of the .Net framework I checked the behavior of the ToString implementation of decimal, which also has a one-argument overload. The decimal ToString does not throw an exception for a `null` argument. It also returns the default ToString result when using the `string.Empty` format

Having said that, reading the websites above I cannot find text that says that the expected behavior for `string.Empty` should be specified. So I did not implement that yet. 

I am eager to hear whether this is helpful or not.