### PR TITLE
Compare currency with iso

### DIFF
--- a/src/NodaMoney/Currency.cs
+++ b/src/NodaMoney/Currency.cs
@@ -152,6 +152,16 @@ namespace NodaMoney
         /// <returns>The result of the operator.</returns>
         public static bool operator !=(Currency left, Currency right) => !(left == right);
 
+        /// <summary>Check whether the currency is valid at the given date.</summary>
+        /// <param name="date">The date at which the Currency should be valid</param>
+        /// <returns><c>true</c> when the date is within the valid range of this currency; otherwise <c>false</c>;</returns>
+        public bool IsValidAt(DateTime date)
+        {
+            return
+                (!ValidFrom.HasValue || ValidFrom <= date) &&
+                (!ValidTo.HasValue || ValidTo >= date);
+        }
+
         /// <summary>Create an instance of the <see cref="Currency"/>, based on a ISO 4217 currency code.</summary>
         /// <param name="code">A ISO 4217 currency code, like EUR or USD.</param>
         /// <returns>An instance of the type <see cref="Currency"/>.</returns>

--- a/tests/NodaMoney.Tests/CurrencySpec.cs
+++ b/tests/NodaMoney.Tests/CurrencySpec.cs
@@ -7,6 +7,9 @@ using System.Linq;
 using FluentAssertions;
 using Xunit;
 using System.Xml.Serialization;
+using System.Xml.Linq;
+using System.Threading.Tasks;
+using System.Net;
 
 namespace NodaMoney.Tests.CurrencySpec
 {
@@ -518,6 +521,156 @@ namespace NodaMoney.Tests.CurrencySpec
             currency.IsValidAt(DateTime.MaxValue).Should().BeTrue();
             currency.IsValidAt(new DateTime(2018, 8, 19)).Should().BeFalse();
             currency.IsValidAt(new DateTime(2018, 8, 20)).Should().BeTrue();
+        }
+    }
+
+    public class GivenIWantToCompareCurrenciesToIsoXML
+    {
+        private IEnumerable<Currency> _definedCurrencies;
+        private IEnumerable<IsoCurrency> _isoCurrencies;
+
+        private const string FilePath = @"..\..\iso.xml";
+        private bool FileFound { get; set; }
+        private DateTime Date { get; set; }
+
+        private class IsoCurrency
+        {
+            public string CountryName { get; set; }
+            public string CurrencyName { get; set; }
+            public string Currency { get; set; }
+            public string CurrencyNumber { get; set; }
+            public string CurrencyMinorUnits { get; set; }
+        }
+
+        public GivenIWantToCompareCurrenciesToIsoXML()
+        {
+            _definedCurrencies =
+                Currency.GetAllCurrencies()
+                .ToList();
+
+            FileFound = File.Exists(FilePath);
+            if (!FileFound) return;
+
+            var document = XDocument.Load(FilePath);
+
+            _isoCurrencies =
+                    document
+                    .Element("ISO_4217")
+                    .Element("CcyTbl")
+                    .Elements("CcyNtry")
+                    .Select(e =>
+                        new IsoCurrency
+                        {
+                            CountryName = e.Element("CtryNm").Value,
+                            CurrencyName = e.Element("CcyNm")?.Value,
+                            Currency = e.Element("Ccy")?.Value,
+                            CurrencyNumber = e.Element("CcyNbr")?.Value,
+                            CurrencyMinorUnits = e.Element("CcyMnrUnts")?.Value
+                        })
+                        .Where(a => !string.IsNullOrEmpty(a.Currency)) // ignore currencies without a currency name
+                        .ToList();
+
+            Date = DateTime.Parse(document.Element("ISO_4217").Attribute("Pblshd").Value);
+        }
+
+        [Fact(Skip = "For debugging.")]
+        public void WhenCurrenciesInISOList_ThenShouldBeDefinedInRegistry()
+        {
+            if (!FileFound) return;
+
+            var missingCurrencies =
+                _isoCurrencies
+                .Where(a => !_definedCurrencies.Any(c => c.Code == a.Currency))
+                .ToList();
+
+            missingCurrencies.Should().HaveCount(0, $"expected defined currencies to contain {string.Join(", ", missingCurrencies.Select(a => a.Currency + " " + a.CurrencyName))}");
+        }
+
+        [Fact(Skip = "For debugging.")]
+        public void WhenCurrenciesInRegistryAndCurrent_ThenTheyShouldAlsoBeDefinedInTheIsoList()
+        {
+            if (!FileFound) return;
+
+            var notDefinedCurrencies =
+                _definedCurrencies
+                .Where(c => c.IsValidAt(Date))
+                .Where(c => !string.IsNullOrEmpty(c.Number))
+                .Where(c => !_isoCurrencies.Any(a => a.Currency == c.Code))
+                .ToList();
+
+            notDefinedCurrencies.Should().HaveCount(0, $"did not expect currencies to contain {string.Join(", ", notDefinedCurrencies.Select(a => a.Code))}");
+        }
+
+        [Fact(Skip = "For debugging.")]
+        public void WhenCompareCurrencies_ThenTheyShouldHaveTheSameEnglishName()
+        {
+            if (!FileFound) return;
+
+            var differences = new List<string>();
+            foreach (var c in _definedCurrencies)
+            {
+                var found = _isoCurrencies.Where(x => x.Currency == c.Code).ToList();
+
+                if (found.Count == 0) continue;
+                var a = found.First();
+                // ignore casing (for now)
+                if (!string.Equals(c.EnglishName, a.CurrencyName, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    differences.Add($"{ c.Code}: expected '{a.CurrencyName}' but found '{c.EnglishName}'");
+                }
+            }
+            differences.Should().HaveCount(0, string.Join(Environment.NewLine, differences));
+        }
+
+        [Fact(Skip = "For debugging.")]
+        public void WhenCompareCurrencies_ThenTheyShouldHaveTheSameNumber()
+        {
+            if (!FileFound) return;
+
+            var differences = new List<string>();
+            foreach (var c in _definedCurrencies)
+            {
+                var found = _isoCurrencies.Where(x => x.Currency == c.Code).ToList();
+
+                if (found.Count == 0) continue;
+                var a = found.First();
+                // ignore casing (for now)
+                if (!string.Equals(c.Number, a.CurrencyNumber, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    differences.Add($"{c.Code}: expected {a.CurrencyNumber} but found {c.Number}");
+                }
+            }
+            differences.Should().HaveCount(0, string.Join(Environment.NewLine, differences));
+        }
+
+        [Fact(Skip = "For debugging.")]
+        public void WhenCompareCurrencies_ThenTheyShouldHaveTheSameNumberOfMinorDigits()
+        {
+            if (!FileFound) return;
+
+            var differences = new List<string>();
+            foreach (var c in _definedCurrencies)
+            {
+                var found = _isoCurrencies.Where(x => x.Currency == c.Code).ToList();
+
+                if (found.Count == 0) continue;
+                var a = found.First();
+                if (!string.Equals(c.DecimalDigits.ToString(), a.CurrencyMinorUnits, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    if (c.DecimalDigits == -1 && a.CurrencyMinorUnits == "N.A.") continue;
+                    differences.Add($"{c.Code}: expected {a.CurrencyMinorUnits} minor units but found {c.DecimalDigits}");
+                }
+            }
+            differences.Should().HaveCount(0, string.Join(Environment.NewLine, differences));
+        }
+
+        [Fact(Skip = "For debugging.")]
+        public async Task UpdateTheStoredIsoFileOnDisk()
+        {
+            using (var client = new WebClient())
+            {
+                await client.DownloadFileTaskAsync(new Uri("https://www.currency-iso.org/dam/downloads/lists/list_one.xml"), FilePath);
+            }
         }
     }
 }

--- a/tests/NodaMoney.Tests/CurrencySpec.cs
+++ b/tests/NodaMoney.Tests/CurrencySpec.cs
@@ -88,7 +88,7 @@ namespace NodaMoney.Tests.CurrencySpec
             }
         }
     }
-
+    
     public class GivenIWantCurrencyFromIsoCode
     {
         [Fact]
@@ -472,6 +472,52 @@ namespace NodaMoney.Tests.CurrencySpec
             code.Should().Be("EUR");
             number.Should().Be("978");
             symbol.Should().Be("€");
+        }
+    }
+
+    public class GivenIWantToValidateTheDateRange
+    {
+        [Fact]
+        public void WhenValidatingACurrencyThatIsAlwaysValid_ThenShouldSucceed()
+        {
+            var currency = Currency.FromCode("EUR");
+
+            currency.ValidFrom.Should().BeNull();
+            currency.ValidTo.Should().BeNull();
+
+            currency.IsValidAt(DateTime.Today).Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenValidatingACurrencyThatIsValidUntilACertainDate_ThenShouldBeValidStrictlyBeforeThatDate()
+        {
+            var currency = Currency.FromCode("VEB");
+
+            currency.ValidFrom.Should().BeNull();
+            currency.ValidTo.Should().Be(new DateTime(2008, 1, 1));
+
+            currency.IsValidAt(DateTime.MinValue).Should().BeTrue();
+            currency.IsValidAt(DateTime.MaxValue).Should().BeFalse();
+            currency.IsValidAt(new DateTime(2007, 12, 31)).Should().BeTrue();
+            // assumes that the until date given in the wikipedia article is excluding.
+            // assumption based on the fact that some dates are the first of the month/year
+            // and that the euro started at 1999-01-01. Given that the until date of e.g. the Dutch guilder
+            // is 1999-01-01, the until date must be excluding
+            currency.IsValidAt(new DateTime(2008, 1, 1)).Should().BeTrue("the until date is excluding");
+        }
+
+        [Fact]
+        public void WhenValidatingACurrencyThatIsValidFromACertainDate_ThenShouldBeValidFromThatDate()
+        {
+            var currency = Currency.FromCode("VES");
+
+            currency.ValidFrom.Should().Be(new DateTime(2018, 8, 20));
+            currency.ValidTo.Should().BeNull();
+
+            currency.IsValidAt(DateTime.MinValue).Should().BeFalse();
+            currency.IsValidAt(DateTime.MaxValue).Should().BeTrue();
+            currency.IsValidAt(new DateTime(2018, 8, 19)).Should().BeFalse();
+            currency.IsValidAt(new DateTime(2018, 8, 20)).Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
I have created some tests to automatically validate the data in [here](https://www.currency-iso.org/dam/downloads/lists/list_one.xml) with the Currency registry. To prevent problems, the tests are skipped so that the build can still succeed. Having made this comparison, I notice a few differences, most of them minor, but some may be more serious. I do not want to make any changes to the registry before discussing this more.

- BYN (Belarusian Ruble) has number 974 in the Currency registry, but in the xml 933, also on [Wikipedia ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) it specifies 933 as the number.
- VNC (Vietnamese old Dong) is historical, but does not have an end date, so technically the currency is still valid. According to [Wikipedia](https://en.wikipedia.org/wiki/Vietnamese_%C4%91%E1%BB%93ng) the end date can be May 3rd 1978
- The number of minor units for some currencies do not match up. Some of them might be correct because of the five subunits. I did not look into this further
- The name of the currencies in the xml is slightly different. Most differences are because the registry includes the country in the name. E.g. GEL 'Georgian lari' vs 'Lari' (Not important I think)

Also I added an `IsValidAt` method to Currency to have an easy check whether a Currency is valid at a certain date.