### PR TITLE
first attempt at implementing the "F" formatting code

### DIFF
--- a/src/NodaMoney/Money.Formattable.cs
+++ b/src/NodaMoney/Money.Formattable.cs
@@ -125,6 +125,12 @@ namespace NodaMoney
                 format = "C";
             }
 
+            if (format.StartsWith("F", StringComparison.CurrentCulture))
+            {
+                format = format.Replace("F", "N");
+                return $"{Amount.ToString(format, provider)} {Currency.EnglishName}";
+            }
+
             return Amount.ToString(format ?? "C", provider);
         }
     }

--- a/tests/NodaMoney.Tests/MoneyFormattableSpec.cs
+++ b/tests/NodaMoney.Tests/MoneyFormattableSpec.cs
@@ -241,7 +241,7 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
             _dollar.ToString("I").Should().Be("USD 765,43");
             _dinar.ToString("I").Should().Be("BHD 765,432");
         }
-
+        
         [Fact]
         [UseCulture("fr-FR")]
         public void WhenCurrentCultureFR_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureFR()
@@ -301,6 +301,86 @@ namespace NodaMoney.Tests.MoneyFormattableSpec
             _euro.ToString("I4").Should().Be("EUR 765.4300");
             _dollar.ToString("I4").Should().Be("USD 765.4300");
             _dinar.ToString("I4").Should().Be("BHD 765.4320");
+        }
+    }
+
+    public class GivenIWantMoneyAsStringWithEnglishCurrencyName
+    {
+        private Money _yen = new Money(765.4321m, Currency.FromCode("JPY"));
+        private Money _euro = new Money(765.4321m, Currency.FromCode("EUR"));
+        private Money _dollar = new Money(765.4321m, Currency.FromCode("USD"));
+        private Money _dinar = new Money(765.4321m, Currency.FromCode("BHD"));
+
+        [Fact]
+        [UseCulture("pt-BR")]
+        public void WhenCurrentCulturePTBR_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCulturePtBRAndCurrencyNameIsInEnglish()
+        {
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be("pt-BR");
+            _yen.ToString("F").Should().Be("765,00 Japanese yen");
+            _euro.ToString("F").Should().Be("765,43 Euro");
+            _dollar.ToString("F").Should().Be("765,43 United States dollar");
+            _dinar.ToString("F").Should().Be("765,43 Bahraini dinar");
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public void WhenCurrentCultureEnUS_ThenDecimalsFollowsCurrencyAndAmountFollowsCurrentCultureEnUSAndCurrencyNameIsInEnglish()
+        {
+            Thread.CurrentThread.CurrentCulture.Name.Should().Be("en-US");
+            _yen.ToString("F").Should().Be("765.00 Japanese yen");
+            _euro.ToString("F").Should().Be("765.43 Euro");
+            _dollar.ToString("F").Should().Be("765.43 United States dollar");
+            _dinar.ToString("F").Should().Be("765.43 Bahraini dinar");
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public void WhenZeroDecimals_ThenThisShouldSucceed()
+        {
+            _yen.ToString("F0").Should().Be("765 Japanese yen");
+            _euro.ToString("F0").Should().Be("765 Euro");
+            _dollar.ToString("F0").Should().Be("765 United States dollar");
+            _dinar.ToString("F0").Should().Be("765 Bahraini dinar");
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public void WhenOneDecimals_ThenThisShouldSucceed()
+        {
+            _yen.ToString("F1").Should().Be("765.0 Japanese yen");
+            _euro.ToString("F1").Should().Be("765.4 Euro");
+            _dollar.ToString("F1").Should().Be("765.4 United States dollar");
+            _dinar.ToString("F1").Should().Be("765.4 Bahraini dinar");
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public void WhenTwoDecimals_ThenThisShouldSucceed()
+        {
+            _yen.ToString("F2").Should().Be("765.00 Japanese yen");
+            _euro.ToString("F2").Should().Be("765.43 Euro");
+            _dollar.ToString("F2").Should().Be("765.43 United States dollar");
+            _dinar.ToString("F2").Should().Be("765.43 Bahraini dinar");
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public void WhenThreeDecimals_ThenThisShouldSucceed()
+        {
+            _yen.ToString("F3").Should().Be("765.000 Japanese yen");
+            _euro.ToString("F3").Should().Be("765.430 Euro");
+            _dollar.ToString("F3").Should().Be("765.430 United States dollar");
+            _dinar.ToString("F3").Should().Be("765.432 Bahraini dinar");
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public void WhenFourDecimals_ThenThisShouldSucceed()
+        {
+            _yen.ToString("F4").Should().Be("765.0000 Japanese yen");
+            _euro.ToString("F4").Should().Be("765.4300 Euro");
+            _dollar.ToString("F4").Should().Be("765.4300 United States dollar");
+            _dinar.ToString("F4").Should().Be("765.4320 Bahraini dinar");
         }
     }
 }


### PR DESCRIPTION
First primitive attempt at changing "ToString" so it supports the "F" formatting code.
The idea is that, by using this code, the user gets back the currency as string, with decimal
places according to the current currency, number formatting according to the thread culture
OR the specified IFormatProvider, followed by the currency name in English.